### PR TITLE
Change the domain names specified in the Ingress

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.5
+version: 0.6.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/templates/ingress.yaml
+++ b/charts/thub/templates/ingress.yaml
@@ -27,7 +27,7 @@ metadata:
     alb.ingress.kubernetes.io/tags: k8s.namespace/{{ .Release.Namespace }}={{ .Release.Namespace }}
 spec:
   rules:
-    - host: {{ print "ojt." $namespace "." $domain | quote }}
+    - host: {{ print "ojt-" $namespace "." $domain | quote }}
       http:
         paths:
           {{- if $useV1Ingress }}
@@ -44,7 +44,7 @@ spec:
               serviceName: {{ $ojtServiceName }}
               servicePort: http-grails
           {{- end }}
-    - host: {{ print "dataorchestration." $namespace "." $domain | quote }}
+    - host: {{ print "dataorchestration-" $namespace "." $domain | quote }}
       http:
         paths:
           {{- if $useV1Ingress }}


### PR DESCRIPTION
Change the domain names associated with our thub services to simplify them from 2 levels of subdomains to one level.