### PR TITLE
Grails server url

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.10
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/templates/deployment.yaml
+++ b/charts/thub/charts/lms-data-service/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+          {{- include "thub.lmsDataServiceServerUrlEnv" . | nindent 10 }}
           - name: server.port
             value: {{ .Values.global.lmsDataService.servicePort | quote }}
           # The keycloak-shared-secret and keycloak-realm-secret are defined in the keycloak-config chart

--- a/charts/thub/charts/ojt/Chart.yaml
+++ b/charts/thub/charts/ojt/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.8
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/ojt/templates/deployment.yaml
+++ b/charts/thub/charts/ojt/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+          {{- include "thub.ojtServerUrlEnv" . | nindent 10 }}
           - name: services.user
             value: "http://{{ .Values.global.userService.serviceName }}:{{ .Values.global.userService.servicePort }}"
           - name: services.item

--- a/charts/thub/templates/NOTES.txt
+++ b/charts/thub/templates/NOTES.txt
@@ -9,5 +9,6 @@ To learn more about the release, try:
 
 1. Get the application URL by running these commands:
 {{- if .Values.global.ingress.enabled }}
-{{ include "thub.ojtServerUrl" . }}
+{{ print "https://" (include "thub.ojtServerUrl" .) | quote }}
+{{ print "https://" (include "thub.lmsDataServiceServerUrl" .) | quote }}
 {{- end }}

--- a/charts/thub/templates/NOTES.txt
+++ b/charts/thub/templates/NOTES.txt
@@ -8,10 +8,6 @@ To learn more about the release, try:
   $ helm get all {{ .Release.Name }}
 
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
+{{- if .Values.global.ingress.enabled }}
+{{ include "thub.ojtServerUrl" . }}
 {{- end }}

--- a/charts/thub/templates/_helpers.tpl
+++ b/charts/thub/templates/_helpers.tpl
@@ -95,6 +95,25 @@ Create the OJT Server URL / Ingress path Environment Variable
 {{- end }}
 
 {{/*
+Create the LMS Data Service Server URL / Ingress path
+*/}}
+{{- define "thub.lmsDataServiceServerUrl" -}}
+{{- if .Values.global.ingress.enabled -}}
+{{ print "dataorchestration-" .Release.Namespace "." .Values.global.ingress.domain }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the LMS Data Service Server URL / Ingress path Environment Variable
+*/}}
+{{- define "thub.lmsDataServiceServerUrlEnv" -}}
+{{- if .Values.global.ingress.enabled -}}
+- name: grails.serverURL
+  value: {{ print "https://" (include "thub.lmsDataServiceServerUrl" .) | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the contents of the Grails JMS properties file configmap
 */}}
 {{- define "thub.grailsAppConfigmapPropertiesFile" -}}

--- a/charts/thub/templates/_helpers.tpl
+++ b/charts/thub/templates/_helpers.tpl
@@ -76,6 +76,25 @@ Create the name of the LMS Data Service job queue
 {{- end }}
 
 {{/*
+Create the OJT Server URL / Ingress path
+*/}}
+{{- define "thub.ojtServerUrl" -}}
+{{- if .Values.global.ingress.enabled -}}
+{{ print "ojt-" .Release.Namespace "." .Values.global.ingress.domain }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the OJT Server URL / Ingress path Environment Variable
+*/}}
+{{- define "thub.ojtServerUrlEnv" -}}
+{{- if .Values.global.ingress.enabled -}}
+- name: grails.serverURL
+  value: {{ print "https://" (include "thub.ojtServerUrl" .) | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the contents of the Grails JMS properties file configmap
 */}}
 {{- define "thub.grailsAppConfigmapPropertiesFile" -}}

--- a/charts/thub/templates/ingress.yaml
+++ b/charts/thub/templates/ingress.yaml
@@ -1,8 +1,6 @@
 {{- if .Values.global.ingress.enabled -}}
 {{- $fullName := include "thub.fullname" . -}}
 {{- $ojtServiceName := .Values.global.ojt.serviceName -}}
-{{- $domain := .Values.global.ingress.domain -}}
-{{- $namespace := .Release.Namespace -}}
 {{- $useV1Ingress := and (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") .Values.global.ingress.enablePathType -}}
 {{- if $useV1Ingress -}}
 apiVersion: networking.k8s.io/v1
@@ -44,7 +42,7 @@ spec:
               serviceName: {{ $ojtServiceName }}
               servicePort: http-grails
           {{- end }}
-    - host: {{ print "dataorchestration-" $namespace "." $domain | quote }}
+    - host: {{ include "thub.lmsDataServiceServerUrl" . | quote }}
       http:
         paths:
           {{- if $useV1Ingress }}

--- a/charts/thub/templates/ingress.yaml
+++ b/charts/thub/templates/ingress.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.global.ingress.enabled -}}
 {{- $fullName := include "thub.fullname" . -}}
 {{- $ojtServiceName := .Values.global.ojt.serviceName -}}
-{{- $domain := .Values.ingress.domain -}}
+{{- $domain := .Values.global.ingress.domain -}}
 {{- $namespace := .Release.Namespace -}}
-{{- $useV1Ingress := and (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") .Values.ingress.enablePathType -}}
+{{- $useV1Ingress := and (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") .Values.global.ingress.enablePathType -}}
 {{- if $useV1Ingress -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -17,17 +17,17 @@ metadata:
   labels:
     {{- include "thub.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.group.enabled }}
-    alb.ingress.kubernetes.io/group.name: {{ required "ingress.group.name is required when ingress.group.enabled is true" .Values.ingress.group.name }}
+    {{- if .Values.global.ingress.group.enabled }}
+    alb.ingress.kubernetes.io/group.name: {{ required "ingress.group.name is required when ingress.group.enabled is true" .Values.global.ingress.group.name }}
     {{- end }}
-    {{- with .Values.ingress.annotations }}
+    {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     # Add these tags to the AWS Application Load Balancer
     alb.ingress.kubernetes.io/tags: k8s.namespace/{{ .Release.Namespace }}={{ .Release.Namespace }}
 spec:
   rules:
-    - host: {{ print "ojt-" $namespace "." $domain | quote }}
+    - host: {{ include "thub.ojtServerUrl" . | quote }}
       http:
         paths:
           {{- if $useV1Ingress }}

--- a/charts/thub/values.yaml
+++ b/charts/thub/values.yaml
@@ -58,28 +58,6 @@ sflms:
   # See [ConnectivityConfig.groovy](https://github.com/hypercision/sflms-data-service/blob/68d82a19a619bbd85d075608e4d3276b68d524a2/grails-app/domain/com/hclabs/connectivity/ConnectivityConfig.groovy#L27)
   connectorSuffix: ""
 
-ingress:
-  enabled: true
-  # This can be set to true once AWS Load Balancer supports pathType.
-  # Setting it to true at the moment results in an ingress that does not work as expected.
-  # https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1772
-  enablePathType: false
-  group:
-    # Set this to true in order to share an application load balancer
-    # across multiple ingress resources using IngressGroups
-    enabled: false
-    name: ""
-  annotations:
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    # If we want to allow unencrypted access, we can change it to '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
-    alb.ingress.kubernetes.io/healthcheck-path: /healthCheck
-    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
-  domain: "hcl-testcloud.com"
-
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -291,6 +269,27 @@ global:
   awsS3AccessConfigMapName: aws-s3-access-config
   jmsPropertiesConfigMapName: jms-properties-grails-app-config
   sharedSettingsConfigMapName: shared-settings-config
+  ingress:
+    enabled: true
+    # This can be set to true once AWS Load Balancer supports pathType.
+    # Setting it to true at the moment results in an ingress that does not work as expected.
+    # https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1772
+    enablePathType: false
+    group:
+      # Set this to true in order to share an application load balancer
+      # across multiple ingress resources using IngressGroups
+      enabled: false
+      name: ""
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      # If we want to allow unencrypted access, we can change it to '[{"HTTP": 80}, {"HTTPS": 443}]'
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+      alb.ingress.kubernetes.io/healthcheck-path: /healthCheck
+      alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
+    domain: "hcl-testcloud.com"
   # Resources for the thub-event-scheduler-job container
   eventSchedulerResources:
     requests:


### PR DESCRIPTION
Add a `grails.serverURL` environment variable to OJT and LMS Data Service. This required moving the `thub` ingress values into `.Values.global.ingress`.