### PR TITLE
Update ApiVersion for the CronJobs

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/Chart.yaml
+++ b/charts/thub/charts/assigned-item-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/templates/resubmit-ojts-scheduler-job.yaml
+++ b/charts/thub/charts/assigned-item-service/templates/resubmit-ojts-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.resubmitOjtsSchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "assigned-item-service.resubmitOjtsSchedulerJobName" . }}

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/templates/assigned-items-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/assigned-items-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.assignedItemsSchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "lms-data-service.assignedItemsSchedulerJobName" . }}

--- a/charts/thub/charts/lms-data-service/templates/end-incomplete-jobs-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/end-incomplete-jobs-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.endIncompleteJobsSchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "lms-data-service.endIncompleteJobsSchedulerJobName" . }}

--- a/charts/thub/charts/lms-data-service/templates/instructors-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/instructors-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.instructorsSchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "lms-data-service.instructorsSchedulerJobName" . }}

--- a/charts/thub/charts/lms-data-service/templates/items-inactive-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/items-inactive-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.itemsInactiveSchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "lms-data-service.itemsInactiveSchedulerJobName" . }}

--- a/charts/thub/charts/lms-data-service/templates/items-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/items-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.itemsSchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "lms-data-service.itemsSchedulerJobName" . }}

--- a/charts/thub/charts/lms-data-service/templates/learners-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/learners-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.learnersSchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "lms-data-service.learnersSchedulerJobName" . }}

--- a/charts/thub/charts/lms-data-service/templates/learning-history-upload-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/learning-history-upload-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.learningHistoryUploadJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: lms-learning-history-upload-job

--- a/charts/thub/charts/ojt/Chart.yaml
+++ b/charts/thub/charts/ojt/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/ojt/templates/learning-history-scheduler-job.yaml
+++ b/charts/thub/charts/ojt/templates/learning-history-scheduler-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.learningHistorySchedulerJob.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "ojt.learningHistorySchedulerJobName" . }}


### PR DESCRIPTION
`batch/v1beta1 CronJob` is deprecated in Kubernetes v1.21+, unavailable in v1.25+; use `batch/v1 CronJob`

I tested the changes out in our dev environment and confirmed everything works as expected.