### PR TITLE
Add Liquibase init container to Item Service deployment

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/item-service/Chart.yaml
+++ b/charts/thub/charts/item-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/item-service/templates/datasource-configmap.yaml
+++ b/charts/thub/charts/item-service/templates/datasource-configmap.yaml
@@ -9,3 +9,4 @@ data:
   dataSource.username: {{ required "dataSource.username cannot be emtpy" .Values.dataSource.username | quote }}
   dataSource.password: {{ required "dataSource.password cannot be emtpy" .Values.dataSource.password | quote }}
   dataSource.url: {{ .Values.dataSource.url | quote }}
+  liquibaseUrl: {{ .Values.liquibaseUrl | quote }}

--- a/charts/thub/charts/item-service/templates/deployment.yaml
+++ b/charts/thub/charts/item-service/templates/deployment.yaml
@@ -60,6 +60,32 @@ spec:
           - name: application-config
             mountPath: /app/config
             readOnly: true
+      {{- if .Values.liquibaseImage.enabled }}
+      initContainers:
+        - name: "liquibase-{{ .Chart.Name }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.liquibaseImage.repository }}:{{ .Values.liquibaseImage.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.liquibaseImage.pullPolicy }}
+          resources:
+            {{- toYaml .Values.liquibaseResources | nindent 12 }}
+          env:
+          - name: URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "item-service.datasourceConfigmapName" . }}
+                key: liquibaseUrl
+          - name: USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "item-service.datasourceConfigmapName" . }}
+                key: dataSource.username
+          - name: PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "item-service.datasourceConfigmapName" . }}
+                key: dataSource.password
+      {{- end }}
       volumes:
         - name: application-config
           configMap:

--- a/charts/thub/charts/item-service/values.yaml
+++ b/charts/thub/charts/item-service/values.yaml
@@ -7,6 +7,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+liquibaseImage:
+  enabled: true
+  repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/liquibase-item-service
+  pullPolicy: IfNotPresent
+  # Overrides the liquibase image tag whose default is the chart appVersion.
+  tag: ""
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -15,6 +22,8 @@ dataSource:
   username: ""
   password: ""
   url: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name"
+# Same database URL, but potentially with different parameters
+liquibaseUrl: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name?useSSL=false"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -58,6 +67,18 @@ service:
   type: ClusterIP
 
 resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+liquibaseResources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/thub/values.yaml
+++ b/charts/thub/values.yaml
@@ -100,16 +100,15 @@ assigned-item-service:
     schedule: "4 */6 * * *"
 
 item-service:
-  resources:
-    requests:
-      memory: 650M
-    limits:
-      memory: 725M
+  resources: {}
+  liquibaseResources: {}
   # The datasource info for connecting the Grails applciation to the database
   dataSource:
     username: ""
     password: ""
     url: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name"
+  # Same database URL, but potentially with different parameters
+  liquibaseUrl: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name?useSSL=false"
   # Liveness probe configuration
   livenessProbe: |
     httpGet:


### PR DESCRIPTION
Associated Item Service changes: [hypercision/traininghub#203](https://github.com/hypercision/item-service/pull/6)

Run a Liquibase init container before the Item Service deployment containers run. The init container has all the Liquibase XML database migration files that are stored in the Item Service repo at the exact same git revision as the Item Service application docker image.

Before deploying these changes with `liquibaseImage.enabled` set to `true` to an existing environment, I will need to run the following SQL:

```
UPDATE hclabs_dev_item.DATABASECHANGELOG 
SET 
    FILENAME = REPLACE(FILENAME,
        '.groovy',
        '.xml')
WHERE
    FILENAME LIKE "%.groovy";


UPDATE hclabs_dev_item.DATABASECHANGELOG
SET MD5SUM=NULL;
```