### PR TITLE
Add Liquibase init container to LMS Data Service deployment

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/templates/datasource-configmap.yaml
+++ b/charts/thub/charts/lms-data-service/templates/datasource-configmap.yaml
@@ -9,3 +9,4 @@ data:
   dataSource.username: {{ required "dataSource.username cannot be emtpy" .Values.dataSource.username | quote }}
   dataSource.password: {{ required "dataSource.password cannot be emtpy" .Values.dataSource.password | quote }}
   dataSource.url: {{ .Values.dataSource.url | quote }}
+  liquibaseUrl: {{ .Values.liquibaseUrl | quote }}

--- a/charts/thub/charts/lms-data-service/templates/deployment.yaml
+++ b/charts/thub/charts/lms-data-service/templates/deployment.yaml
@@ -89,6 +89,32 @@ spec:
           - name: application-config
             mountPath: /app/config
             readOnly: true
+      {{- if .Values.liquibaseImage.enabled }}
+      initContainers:
+        - name: "liquibase-{{ .Chart.Name }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.liquibaseImage.repository }}:{{ .Values.liquibaseImage.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.liquibaseImage.pullPolicy }}
+          resources:
+            {{- toYaml .Values.liquibaseResources | nindent 12 }}
+          env:
+          - name: URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "lms-data-service.datasourceConfigmapName" . }}
+                key: liquibaseUrl
+          - name: USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "lms-data-service.datasourceConfigmapName" . }}
+                key: dataSource.username
+          - name: PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "lms-data-service.datasourceConfigmapName" . }}
+                key: dataSource.password
+      {{- end }}
       volumes:
         - name: application-config
           configMap:

--- a/charts/thub/charts/lms-data-service/values.yaml
+++ b/charts/thub/charts/lms-data-service/values.yaml
@@ -7,6 +7,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+liquibaseImage:
+  enabled: true
+  repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/liquibase-sflms-data-service
+  pullPolicy: IfNotPresent
+  # Overrides the liquibase image tag whose default is the chart appVersion.
+  tag: ""
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -15,6 +22,8 @@ dataSource:
   username: ""
   password: ""
   url: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name"
+# Same database URL, but potentially with different parameters
+liquibaseUrl: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name?useSSL=false"
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -58,6 +67,18 @@ service:
   type: ClusterIP
 
 resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+liquibaseResources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/thub/values.yaml
+++ b/charts/thub/values.yaml
@@ -125,16 +125,15 @@ item-service:
     timeoutSeconds: 3
 
 lms-data-service:
-  resources:
-    requests:
-      memory: 710M
-    limits:
-      memory: 800M
+  resources: {}
+  liquibaseResources: {}
   # The datasource info for connecting the Grails applciation to the database
   dataSource:
     username: ""
     password: ""
     url: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name"
+  # Same database URL, but potentially with different parameters
+  liquibaseUrl: "jdbc:mysql://example.us-east-1.rds.amazonaws.com:3306/schema_name?useSSL=false"
   # Liveness probe configuration
   livenessProbe: |
     httpGet:


### PR DESCRIPTION
Associated LMS Data Service changes: [hypercision/traininghub#203](https://github.com/hypercision/sflms-data-service/pull/9)

Run a Liquibase init container before the LMS Data Service deployment containers run. The init container has all the Liquibase XML database migration files that are stored in the OJT repo at the exact same git revision as the LMS Data Service application Docker image.