### PR TITLE
Change the config file mount location to support the new thub services

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.8
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/Chart.yaml
+++ b/charts/thub/charts/assigned-item-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/templates/deployment.yaml
+++ b/charts/thub/charts/assigned-item-service/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
               name: {{ .Values.global.sharedSettingsConfigMapName }}
           volumeMounts:
           - name: application-config
-            mountPath: /app/config
+            mountPath: /home/app/config
             readOnly: true
       {{- if .Values.liquibaseImage.enabled }}
       initContainers:

--- a/charts/thub/charts/item-service/Chart.yaml
+++ b/charts/thub/charts/item-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/item-service/templates/deployment.yaml
+++ b/charts/thub/charts/item-service/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
               name: {{ .Values.global.sharedSettingsConfigMapName }}
           volumeMounts:
           - name: application-config
-            mountPath: /app/config
+            mountPath: /home/app/config
             readOnly: true
       {{- if .Values.liquibaseImage.enabled }}
       initContainers:

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/templates/deployment.yaml
+++ b/charts/thub/charts/lms-data-service/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
               name: keycloak-realm-config
           volumeMounts:
           - name: application-config
-            mountPath: /app/config
+            mountPath: /home/app/config
             readOnly: true
       {{- if .Values.liquibaseImage.enabled }}
       initContainers:

--- a/charts/thub/charts/ojt/Chart.yaml
+++ b/charts/thub/charts/ojt/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/ojt/templates/deployment.yaml
+++ b/charts/thub/charts/ojt/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
               name: keycloak-realm-config
           volumeMounts:
           - name: application-config
-            mountPath: /app/config
+            mountPath: /home/app/config
             readOnly: true
       {{- if .Values.liquibaseImage.enabled }}
       initContainers:

--- a/charts/thub/charts/user-service/Chart.yaml
+++ b/charts/thub/charts/user-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/user-service/templates/deployment.yaml
+++ b/charts/thub/charts/user-service/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
               name: keycloak-realm-config
           volumeMounts:
           - name: application-config
-            mountPath: /app/config
+            mountPath: /home/app/config
             readOnly: true
       {{- if .Values.liquibaseImage.enabled }}
       initContainers:


### PR DESCRIPTION
Change the config file mount location to support the new thub service images which use JDK 11. Since this is a breaking change, I have incremented the major version of each affected chart.