### PR TITLE
Roll the appropriate deployments when JMS properties ConfigMap changes

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/Chart.yaml
+++ b/charts/thub/charts/assigned-item-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/templates/deployment.yaml
+++ b/charts/thub/charts/assigned-item-service/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         # Automatically roll deployment when a configmap file changes
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/datasource-config: {{ include (print $.Template.BasePath "/datasource-configmap.yaml") . | sha256sum }}
+        checksum/jms-properties-config: {{ include "thub.grailsAppConfigmapPropertiesFile" . | sha256sum }}
       labels:
         {{- include "assigned-item-service.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/thub/charts/item-service/Chart.yaml
+++ b/charts/thub/charts/item-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/item-service/templates/deployment.yaml
+++ b/charts/thub/charts/item-service/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         # Automatically roll deployment when a configmap file changes
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/datasource-config: {{ include (print $.Template.BasePath "/datasource-configmap.yaml") . | sha256sum }}
+        checksum/jms-properties-config: {{ include "thub.grailsAppConfigmapPropertiesFile" . | sha256sum }}
       labels:
         {{- include "item-service.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/templates/deployment.yaml
+++ b/charts/thub/charts/lms-data-service/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/datasource-config: {{ include (print $.Template.BasePath "/datasource-configmap.yaml") . | sha256sum }}
         checksum/sftp-config: {{ include (print $.Template.BasePath "/sftp-configmap.yaml") . | sha256sum }}
+        checksum/jms-properties-config: {{ include "thub.grailsAppConfigmapPropertiesFile" . | sha256sum }}
       labels:
         {{- include "lms-data-service.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/thub/charts/ojt/Chart.yaml
+++ b/charts/thub/charts/ojt/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/ojt/templates/deployment.yaml
+++ b/charts/thub/charts/ojt/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         # Automatically roll deployment when a configmap file changes
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/datasource-config: {{ include (print $.Template.BasePath "/datasource-configmap.yaml") . | sha256sum }}
+        checksum/jms-properties-config: {{ include "thub.grailsAppConfigmapPropertiesFile" . | sha256sum }}
       labels:
         {{- include "ojt.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/thub/charts/user-service/Chart.yaml
+++ b/charts/thub/charts/user-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/user-service/templates/deployment.yaml
+++ b/charts/thub/charts/user-service/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         # Automatically roll deployment when a configmap file changes
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/datasource-config: {{ include (print $.Template.BasePath "/datasource-configmap.yaml") . | sha256sum }}
+        checksum/jms-properties-config: {{ include "thub.grailsAppConfigmapPropertiesFile" . | sha256sum }}
       labels:
         {{- include "user-service.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
When changes are made to the JMS properties ConfigMap, all our service deployments (i.e. OJT, User Service, etc.) will roll so that they load the new JMS properties.