### PR TITLE
Add labels and annotations to the cronjob job templates

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/Chart.yaml
+++ b/charts/thub/charts/assigned-item-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/assigned-item-service/templates/resubmit-ojts-scheduler-job.yaml
+++ b/charts/thub/charts/assigned-item-service/templates/resubmit-ojts-scheduler-job.yaml
@@ -18,6 +18,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.resubmitOjtsSchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.resubmitOjtsSchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/assigned-item-service/values.yaml
+++ b/charts/thub/charts/assigned-item-service/values.yaml
@@ -115,6 +115,8 @@ resubmitOjtsSchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 global:
   # Resources for the thub-event-scheduler-job container

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/templates/assigned-items-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/assigned-items-scheduler-job.yaml
@@ -17,6 +17,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.assignedItemsSchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.assignedItemsSchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/lms-data-service/templates/end-incomplete-jobs-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/end-incomplete-jobs-scheduler-job.yaml
@@ -17,6 +17,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.endIncompleteJobsSchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.endIncompleteJobsSchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/lms-data-service/templates/instructors-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/instructors-scheduler-job.yaml
@@ -17,6 +17,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.instructorsSchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.instructorsSchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/lms-data-service/templates/items-inactive-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/items-inactive-scheduler-job.yaml
@@ -17,6 +17,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.itemsInactiveSchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.itemsInactiveSchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/lms-data-service/templates/items-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/items-scheduler-job.yaml
@@ -17,6 +17,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.itemsSchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.itemsSchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/lms-data-service/templates/learners-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/learners-scheduler-job.yaml
@@ -17,6 +17,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.learnersSchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.learnersSchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/lms-data-service/templates/learning-history-upload-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/learning-history-upload-job.yaml
@@ -17,6 +17,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.learningHistoryUploadJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.learningHistoryUploadJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/lms-data-service/values.yaml
+++ b/charts/thub/charts/lms-data-service/values.yaml
@@ -126,6 +126,8 @@ assignedItemsSchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 endIncompleteJobsSchedulerJob:
   enabled: true
@@ -139,6 +141,8 @@ endIncompleteJobsSchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 instructorsSchedulerJob:
   enabled: true
@@ -152,6 +156,8 @@ instructorsSchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 itemsSchedulerJob:
   enabled: true
@@ -165,6 +171,8 @@ itemsSchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 itemsInactiveSchedulerJob:
   enabled: true
@@ -178,6 +186,8 @@ itemsInactiveSchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 learnersSchedulerJob:
   enabled: true
@@ -191,6 +201,8 @@ learnersSchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 learningHistoryUploadJob:
   enabled: true
@@ -204,6 +216,8 @@ learningHistoryUploadJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 global:
   # Resources for the thub-event-scheduler-job container

--- a/charts/thub/charts/ojt/Chart.yaml
+++ b/charts/thub/charts/ojt/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/ojt/templates/learning-history-scheduler-job.yaml
+++ b/charts/thub/charts/ojt/templates/learning-history-scheduler-job.yaml
@@ -19,6 +19,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            {{- with .Values.learningHistorySchedulerJob.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- with .Values.learningHistorySchedulerJob.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           containers:
           - name: thub-event-scheduler-job

--- a/charts/thub/charts/ojt/values.yaml
+++ b/charts/thub/charts/ojt/values.yaml
@@ -115,6 +115,8 @@ learningHistorySchedulerJob:
     tag: ""
   port: 8099
   restartPolicy: Never
+  podAnnotations: {}
+  podLabels: {}
 
 global:
   # Resources for the thub-event-scheduler-job container


### PR DESCRIPTION
The main impetuous for this enhancement is to be able to add the following annotations to the pods used by our cronjobs:
```
# Annotate the Pod to only have Filebeat parse logs of the correct container as json logs.
# The annotations are of the format: co.elastic.logs.<container_name>
# https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-log.html#filebeat-input-log-config-json
co.elastic.logs.thub-event-scheduler-job/json.keys_under_root: "true"
co.elastic.logs.thub-event-scheduler-job/json.add_error_key: "true"
co.elastic.logs.thub-event-scheduler-job/json.message_key: "message"
co.elastic.logs.thub-event-scheduler-job/json.overwrite_keys: "true"
co.elastic.logs.thub-event-scheduler-job/json.expand_keys: "true"
```