### PR TITLE
Update shell script for updating chart versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
           condition: << pipeline.parameters.update_chart_version >>
           steps:
             - run:
+                name: Run update_app_version_of_chart.sh
                 command: |
                   echo "export GIT_REPOSITORY_URL=$CIRCLE_REPOSITORY_URL" >> $BASH_ENV
                   echo "export GIT_USERNAME=$CIRCLE_PROJECT_USERNAME" >> $BASH_ENV


### PR DESCRIPTION
Update the shell script `.circleci/update_app_version_of_chart.sh` to take into account the new format of Helm charts listing their subcharts. This new format was introduced to our thub chart in the following commit:
https://github.com/hypercision/helm-charts/commit/8398acc4b900d9942417eaf09759897f671b5f3f

Now the shell script updates the version of the subchart in [`charts/thub/Chart.yaml`](https://github.com/hypercision/helm-charts/blob/master/charts/thub/Chart.yaml) as well.