### PR TITLE
Update appVersions of charts to use Keycloak 17 compatible versions

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.16
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 2.0.0
 
 home: https://hypercision.github.io/helm-charts
 
@@ -21,13 +21,13 @@ dependencies:
   - name: item-service
     version: 1.1.2
   - name: keycloak-config
-    version: 0.1.0
+    version: 0.1.1
   - name: lms-data-service
-    version: 1.2.4
+    version: 1.3.0
   - name: ojt
-    version: 1.2.4
+    version: 1.3.0
   - name: user-service
-    version: 1.1.3
+    version: 1.2.0
 
 sources:
   - https://github.com/hypercision/masterdata-services

--- a/charts/thub/charts/keycloak-config/Chart.yaml
+++ b/charts/thub/charts/keycloak-config/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/keycloak-config/values.yaml
+++ b/charts/thub/charts/keycloak-config/values.yaml
@@ -24,4 +24,4 @@ realmAdminPassword: ""
 # Public URL for accessing the Keycloak server on the internet
 publicServerUrl: "https://keycloak.hcl-testcloud.com"
 # URL which is only accessible within the k8s cluster
-internalServerUrl: "http://keycloak-http.keycloak:80"
+internalServerUrl: "http://keycloakx-http.keycloak:80"

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,9 +7,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.4
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.4.2
+appVersion: v2.0.0

--- a/charts/thub/charts/ojt/Chart.yaml
+++ b/charts/thub/charts/ojt/Chart.yaml
@@ -7,9 +7,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.4
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.2.3
+appVersion: v2.0.0

--- a/charts/thub/charts/user-service/Chart.yaml
+++ b/charts/thub/charts/user-service/Chart.yaml
@@ -7,9 +7,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.7.1
+appVersion: v2.0.0

--- a/charts/thub/values.yaml
+++ b/charts/thub/values.yaml
@@ -282,7 +282,7 @@ keycloak-config:
   # Public URL for accessing the Keycloak server on the internet
   publicServerUrl: "https://keycloak.hcl-testcloud.com"
   # URL which is only accessible within the k8s cluster
-  internalServerUrl: "http://keycloak-http.keycloak:80"
+  internalServerUrl: "http://keycloakx-http.keycloak:80"
 
 global:
   activemqBrokerConfigMapName: mq-broker-config


### PR DESCRIPTION
Update the `appVersions` of charts to use application versions that are compatible with Keycloak 17. Also update the default value for the Keycloak `internalServerUrl` to reflect the service name used in the new [Keycloak-X Helm chart](https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx).