### PR TITLE
Bump the default version of thub-event-scheduler-cli-job to 2.0.4

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.2
+version: 1.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/templates/_helpers.tpl
+++ b/charts/thub/templates/_helpers.tpl
@@ -133,5 +133,5 @@ Default tag to use for the 342628741687.dkr.ecr.us-west-2.amazonaws.com/thub-eve
 Docker image
 */}}
 {{- define "thub.eventSchedulerJobTag" -}}
-v2.0.2
+v2.0.4
 {{- end }}


### PR DESCRIPTION
Bump the default version of thub-event-scheduler-cli-job to 2.0.4 from 2.0.2