### PR TITLE
Add configmap for OJT mail config

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ dependencies:
   - name: lms-data-service
     version: 1.5.0
   - name: ojt
-    version: 1.4.11
+    version: 1.4.12
   - name: user-service
     version: 1.3.2
 

--- a/charts/thub/charts/ojt/Chart.yaml
+++ b/charts/thub/charts/ojt/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.11
+version: 1.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/ojt/templates/_helpers.tpl
+++ b/charts/thub/charts/ojt/templates/_helpers.tpl
@@ -69,6 +69,13 @@ Create the name of the Grails datasource configmap
 {{- end }}
 
 {{/*
+Create the name of the OJT application settings configmap
+*/}}
+{{- define "ojt.ojtConfigmapName" -}}
+{{ include "ojt.name" . }}-ojt-app-settings-config
+{{- end }}
+
+{{/*
 Create the name of the CronJob learning-history-scheduler-job
 */}}
 {{- define "ojt.learningHistorySchedulerJobName" -}}

--- a/charts/thub/charts/ojt/templates/deployment.yaml
+++ b/charts/thub/charts/ojt/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
               name: {{ .Values.global.activemqBrokerConfigMapName }}
           - configMapRef:
               name: {{ .Values.global.sharedSettingsConfigMapName }}
+          - configMapRef:
+              name: {{ include "ojt.ojtConfigmapName" . }}
           # The keycloak ConfigMaps are defined in the keycloak-config chart
           - configMapRef:
               name: keycloak-shared-config

--- a/charts/thub/charts/ojt/templates/ojt-configmap.yaml
+++ b/charts/thub/charts/ojt/templates/ojt-configmap.yaml
@@ -1,0 +1,15 @@
+# This will have different values for each client/namespace
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ojt.ojtConfigmapName" . }}
+  labels:
+    {{- include "ojt.labels" . | nindent 4 }}
+  annotations:
+    description: >
+      Contains configuration settings specifically for the OJT Grails application,
+      which will be supplied to the OJT Grails application as environment variables.
+data:
+  {{- if .Values.mail.password }}
+  grails.mail.password: {{ .Values.mail.password | quote }}
+  {{- end }}

--- a/charts/thub/charts/ojt/values.yaml
+++ b/charts/thub/charts/ojt/values.yaml
@@ -109,6 +109,10 @@ tolerations: []
 
 affinity: {}
 
+mail:
+  # "App password" for OJT application to send email from the ojt@hc-labs.com account
+  password: ""
+
 learningHistorySchedulerJob:
   enabled: true
   # Run every 30 minutes

--- a/charts/thub/values.yaml
+++ b/charts/thub/values.yaml
@@ -246,6 +246,9 @@ ojt:
       port: http
     initialDelaySeconds: 40
     timeoutSeconds: 3
+  mail:
+    # "App password" for OJT application to send email from the ojt@hc-labs.com account
+    password: ""
   learningHistorySchedulerJob:
     enabled: true
     # Run every 30 minutes


### PR DESCRIPTION
Add configmap for OJT mail config, specifically the `grails.mail.password`. This can be used with the current version of the OJT Grails application to override the default config.