### PR TITLE
Update scheduler jobs for Workday

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.2
+version: 1.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,7 +23,7 @@ dependencies:
   - name: keycloak-config
     version: 0.1.1
   - name: lms-data-service
-    version: 1.5.0
+    version: 1.5.1
   - name: ojt
     version: 1.4.13
   - name: user-service

--- a/charts/thub/charts/lms-data-service/Chart.yaml
+++ b/charts/thub/charts/lms-data-service/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/lms-data-service/templates/_helpers.tpl
+++ b/charts/thub/charts/lms-data-service/templates/_helpers.tpl
@@ -111,6 +111,17 @@ Create the name of the CronJob assigned-items-scheduler-job
 {{- end }}
 
 {{/*
+Create the name of the JSON file used by the assigned-items-scheduler-job
+*/}}
+{{- define "lms-data-service.assignedItemsSchedulerJobInputFile" -}}
+{{- if .Values.assignedItemsSchedulerJob.jsonInputFile -}}
+{{ print .Values.assignedItemsSchedulerJob.jsonInputFile }}
+{{- else -}}
+{{ print "./temp/start-assigned-items-job.json" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the CronJob lms-end-incomplete-jobs-scheduler-job
 */}}
 {{- define "lms-data-service.endIncompleteJobsSchedulerJobName" -}}
@@ -125,10 +136,36 @@ Create the name of the CronJob instructors-scheduler-job
 {{- end }}
 
 {{/*
+Create the name of the JSON file used by the instructors-scheduler-job
+*/}}
+{{- define "lms-data-service.instructorsSchedulerJobInputFile" -}}
+{{- if .Values.instructorsSchedulerJob.jsonInputFile -}}
+{{ print .Values.instructorsSchedulerJob.jsonInputFile }}
+{{- else if eq .Values.global.lmsType "WORKDAY" -}}
+{{ print "./temp/start-instructors-web-job.json" }}
+{{- else -}}
+{{ print "./temp/start-instructors-job.json" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the CronJob items-scheduler-job
 */}}
 {{- define "lms-data-service.itemsSchedulerJobName" -}}
 {{ include "lms-data-service.name" . }}-items-scheduler-job
+{{- end }}
+
+{{/*
+Create the name of the JSON file used by the items-scheduler-job
+*/}}
+{{- define "lms-data-service.itemsSchedulerJobInputFile" -}}
+{{- if .Values.itemsSchedulerJob.jsonInputFile -}}
+{{ print .Values.itemsSchedulerJob.jsonInputFile }}
+{{- else if eq .Values.global.lmsType "WORKDAY" -}}
+{{ print "./temp/start-items-web-job.json" }}
+{{- else -}}
+{{ print "./temp/start-items-job.json" }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -139,8 +176,45 @@ Create the name of the CronJob items-inactive-scheduler-job
 {{- end }}
 
 {{/*
+Create the name of the JSON file used by the items-inactive-scheduler-job
+*/}}
+{{- define "lms-data-service.itemsInactiveSchedulerJobInputFile" -}}
+{{- if .Values.itemsInactiveSchedulerJob.jsonInputFile -}}
+{{ print .Values.itemsInactiveSchedulerJob.jsonInputFile }}
+{{- else if eq .Values.global.lmsType "WORKDAY" -}}
+{{ print "./temp/start-items-inactive-web-job.json" }}
+{{- else -}}
+{{ print "./temp/start-items-inactive-job.json" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the CronJob learners-scheduler-job
 */}}
 {{- define "lms-data-service.learnersSchedulerJobName" -}}
 {{ include "lms-data-service.name" . }}-learners-scheduler-job
+{{- end }}
+
+{{/*
+Create the name of the JSON file used by the learners-scheduler-job
+*/}}
+{{- define "lms-data-service.learnersSchedulerJobInputFile" -}}
+{{- if .Values.learnersSchedulerJob.jsonInputFile -}}
+{{ print .Values.learnersSchedulerJob.jsonInputFile }}
+{{- else if eq .Values.global.lmsType "WORKDAY" -}}
+{{ print "./temp/start-learners-web-job.json" }}
+{{- else -}}
+{{ print "./temp/start-learners-job.json" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the JSON file used by the learning-history-upload-job
+*/}}
+{{- define "lms-data-service.learningHistoryUploadJobInputFile" -}}
+{{- if .Values.learningHistoryUploadJob.jsonInputFile -}}
+{{ print .Values.learningHistoryUploadJob.jsonInputFile }}
+{{- else -}}
+{{ print "./temp/start-lms-learning-history-job.json" }}
+{{- end }}
 {{- end }}

--- a/charts/thub/charts/lms-data-service/templates/assigned-items-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/assigned-items-scheduler-job.yaml
@@ -31,7 +31,7 @@ spec:
           - name: thub-event-scheduler-job
             image: "{{ .Values.assignedItemsSchedulerJob.image.repository }}:{{ .Values.assignedItemsSchedulerJob.image.tag | default (include "thub.eventSchedulerJobTag" .) }}"
             imagePullPolicy: {{ .Values.assignedItemsSchedulerJob.image.pullPolicy }}
-            command: ["java", "-jar", "/home/app/application.jar", "jms", "./temp/start-assigned-items-job.json"]
+            command: ["java", "-jar", "/home/app/application.jar", "jms", "{{ include "lms-data-service.assignedItemsSchedulerJobInputFile" . }}"]
             ports:
             - containerPort: {{ .Values.assignedItemsSchedulerJob.port }}
               name: http-server

--- a/charts/thub/charts/lms-data-service/templates/event-scheduler-job-input-files-configmap.yaml
+++ b/charts/thub/charts/lms-data-service/templates/event-scheduler-job-input-files-configmap.yaml
@@ -49,6 +49,31 @@ data:
         "instruction": "START",
         "communicationType": "SFTP"
     }
+  # These jobs are used when integrating with Workday LMS
+  start-instructors-web-job.json: |
+    {
+        "type": "INSTRUCTORS",
+        "instruction": "START",
+        "communicationType": "WEBSERVICE"
+    }
+  start-items-web-job.json: |
+    {
+        "type": "ITEMS",
+        "instruction": "START",
+        "communicationType": "WEBSERVICE"
+    }
+  start-items-inactive-web-job.json: |
+    {
+        "type": "ITEMS_INACTIVE",
+        "instruction": "START",
+        "communicationType": "WEBSERVICE"
+    }
+  start-learners-web-job.json: |
+    {
+        "type": "LEARNERS",
+        "instruction": "START",
+        "communicationType": "WEBSERVICE"
+    }
 
 {{/*
 Could use this code if we want to load them from files rather than have them here.

--- a/charts/thub/charts/lms-data-service/templates/event-scheduler-job-input-files-configmap.yaml
+++ b/charts/thub/charts/lms-data-service/templates/event-scheduler-job-input-files-configmap.yaml
@@ -8,15 +8,14 @@ metadata:
     description: >
       This ConfigMap contains files used by thub-event-scheduler-job.
 data:
+  lms-end-incomplete-jobs.json: |
+    {
+        "type": "END_INCOMPLETE_DATA_SYNCS",
+        "instruction": "START"
+    }
   start-assigned-items-job.json: |
     {
         "type": "ASSIGNED_ITEMS",
-        "instruction": "START",
-        "communicationType": "SFTP"
-    }
-  start-lms-learning-history-job.json: |
-    {
-        "type": "LEARNING_HISTORY",
         "instruction": "START",
         "communicationType": "SFTP"
     }
@@ -44,10 +43,11 @@ data:
         "instruction": "START",
         "communicationType": "SFTP"
     }
-  lms-end-incomplete-jobs.json: |
+  start-lms-learning-history-job.json: |
     {
-      "type": "END_INCOMPLETE_DATA_SYNCS",
-      "instruction": "START"
+        "type": "LEARNING_HISTORY",
+        "instruction": "START",
+        "communicationType": "SFTP"
     }
 
 {{/*

--- a/charts/thub/charts/lms-data-service/templates/instructors-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/instructors-scheduler-job.yaml
@@ -31,7 +31,7 @@ spec:
           - name: thub-event-scheduler-job
             image: "{{ .Values.instructorsSchedulerJob.image.repository }}:{{ .Values.instructorsSchedulerJob.image.tag | default (include "thub.eventSchedulerJobTag" .) }}"
             imagePullPolicy: {{ .Values.instructorsSchedulerJob.image.pullPolicy }}
-            command: ["java", "-jar", "/home/app/application.jar", "jms", "./temp/start-instructors-job.json"]
+            command: ["java", "-jar", "/home/app/application.jar", "jms", "{{ include "lms-data-service.instructorsSchedulerJobInputFile" . }}"]
             ports:
             - containerPort: {{ .Values.instructorsSchedulerJob.port }}
               name: http-server

--- a/charts/thub/charts/lms-data-service/templates/items-inactive-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/items-inactive-scheduler-job.yaml
@@ -31,7 +31,7 @@ spec:
           - name: thub-event-scheduler-job
             image: "{{ .Values.itemsInactiveSchedulerJob.image.repository }}:{{ .Values.itemsInactiveSchedulerJob.image.tag | default (include "thub.eventSchedulerJobTag" .) }}"
             imagePullPolicy: {{ .Values.itemsInactiveSchedulerJob.image.pullPolicy }}
-            command: ["java", "-jar", "/home/app/application.jar", "jms", "./temp/start-items-inactive-job.json"]
+            command: ["java", "-jar", "/home/app/application.jar", "jms", "{{ include "lms-data-service.itemsInactiveSchedulerJobInputFile" . }}"]
             ports:
             - containerPort: {{ .Values.itemsInactiveSchedulerJob.port }}
               name: http-server

--- a/charts/thub/charts/lms-data-service/templates/items-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/items-scheduler-job.yaml
@@ -31,7 +31,7 @@ spec:
           - name: thub-event-scheduler-job
             image: "{{ .Values.itemsSchedulerJob.image.repository }}:{{ .Values.itemsSchedulerJob.image.tag | default (include "thub.eventSchedulerJobTag" .) }}"
             imagePullPolicy: {{ .Values.itemsSchedulerJob.image.pullPolicy }}
-            command: ["java", "-jar", "/home/app/application.jar", "jms", "./temp/start-items-job.json"]
+            command: ["java", "-jar", "/home/app/application.jar", "jms", "{{ include "lms-data-service.itemsSchedulerJobInputFile" . }}"]
             ports:
             - containerPort: {{ .Values.itemsSchedulerJob.port }}
               name: http-server

--- a/charts/thub/charts/lms-data-service/templates/learners-scheduler-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/learners-scheduler-job.yaml
@@ -31,7 +31,7 @@ spec:
           - name: thub-event-scheduler-job
             image: "{{ .Values.learnersSchedulerJob.image.repository }}:{{ .Values.learnersSchedulerJob.image.tag | default (include "thub.eventSchedulerJobTag" .) }}"
             imagePullPolicy: {{ .Values.learnersSchedulerJob.image.pullPolicy }}
-            command: ["java", "-jar", "/home/app/application.jar", "jms", "./temp/start-learners-job.json"]
+            command: ["java", "-jar", "/home/app/application.jar", "jms", "{{ include "lms-data-service.learnersSchedulerJobInputFile" . }}"]
             ports:
             - containerPort: {{ .Values.learnersSchedulerJob.port }}
               name: http-server

--- a/charts/thub/charts/lms-data-service/templates/learning-history-upload-job.yaml
+++ b/charts/thub/charts/lms-data-service/templates/learning-history-upload-job.yaml
@@ -31,7 +31,7 @@ spec:
           - name: thub-event-scheduler-job
             image: "{{ .Values.learningHistoryUploadJob.image.repository }}:{{ .Values.learningHistoryUploadJob.image.tag | default (include "thub.eventSchedulerJobTag" .) }}"
             imagePullPolicy: {{ .Values.learningHistoryUploadJob.image.pullPolicy }}
-            command: ["java", "-jar", "/home/app/application.jar", "jms", "./temp/start-lms-learning-history-job.json"]
+            command: ["java", "-jar", "/home/app/application.jar", "jms", "{{ include "lms-data-service.learningHistoryUploadJobInputFile" . }}"]
             ports:
             - containerPort: {{ .Values.learningHistoryUploadJob.port }}
               name: http-server

--- a/charts/thub/charts/lms-data-service/values.yaml
+++ b/charts/thub/charts/lms-data-service/values.yaml
@@ -139,6 +139,8 @@ assignedItemsSchedulerJob:
   # Run on the 15th minute of every hour from 14 thru 23 and 5
   schedule: "15 14-23,5 * * *"
   concurrencyPolicy: "Replace"
+  # Overrides the default JSON file used by the job
+  jsonInputFile: ""
   image:
     repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/thub-event-scheduler-cli-job
     pullPolicy: IfNotPresent
@@ -169,6 +171,8 @@ instructorsSchedulerJob:
   # Run at 2:30 AM every day
   schedule: "30 2 * * *"
   concurrencyPolicy: "Replace"
+  # Overrides the default JSON file used by the job
+  jsonInputFile: ""
   image:
     repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/thub-event-scheduler-cli-job
     pullPolicy: IfNotPresent
@@ -184,6 +188,8 @@ itemsSchedulerJob:
   # Run on the 4th minute of every 4th hour
   schedule: "4 */4 * * *"
   concurrencyPolicy: "Replace"
+  # Overrides the default JSON file used by the job
+  jsonInputFile: ""
   image:
     repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/thub-event-scheduler-cli-job
     pullPolicy: IfNotPresent
@@ -199,6 +205,8 @@ itemsInactiveSchedulerJob:
   # Run on the 50th minute of every 12th hour
   schedule: "50 */12 * * *"
   concurrencyPolicy: "Replace"
+  # Overrides the default JSON file used by the job
+  jsonInputFile: ""
   image:
     repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/thub-event-scheduler-cli-job
     pullPolicy: IfNotPresent
@@ -214,6 +222,8 @@ learnersSchedulerJob:
   # Run on the eigth minute of every 3rd hour
   schedule: "8 */3 * * *"
   concurrencyPolicy: "Replace"
+  # Overrides the default JSON file used by the job
+  jsonInputFile: ""
   image:
     repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/thub-event-scheduler-cli-job
     pullPolicy: IfNotPresent
@@ -229,6 +239,8 @@ learningHistoryUploadJob:
   # Run every 33 minutes
   schedule: "*/33 * * * *"
   concurrencyPolicy: "Replace"
+  # Overrides the default JSON file used by the job
+  jsonInputFile: ""
   image:
     repository: 342628741687.dkr.ecr.us-west-2.amazonaws.com/thub-event-scheduler-cli-job
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Add more job input files (such as `start-instructors-web-job.json`) to be used with the that will work with the `lms-data-service` when integrating with Workday. 

Also, use helm template values to allow us to override the default input files used by scheduler jobs such as `start-assigned-items-job.json`.