### PR TITLE
Set autoVerifyKeycloakUserEmail config property

### DIFF
--- a/charts/thub/Chart.yaml
+++ b/charts/thub/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.6
+version: 1.11.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thub/charts/keycloak-config/templates/keycloak-configmap.yaml
+++ b/charts/thub/charts/keycloak-config/templates/keycloak-configmap.yaml
@@ -34,4 +34,7 @@ data:
   grails.plugin.springsecurity.rest.keycloak.realmAdminUsername: {{ required "realmAdminUsername cannot be emtpy" .Values.realmAdminUsername | quote }}
   # The desired scopes when requesting an access token. This is a space seperated list.
   grails.plugin.springsecurity.rest.keycloak.scopes: {{ .Values.scopes | quote }}
+  # Whether or not to have the users created in Keycloak will automatically have their
+  # "Email verified" property to true
+  keycloak.autoVerifyKeycloakUserEmail: {{ .Values.autoVerifyKeycloakUserEmail | quote }}
 {{- end }}

--- a/charts/thub/charts/keycloak-config/values.yaml
+++ b/charts/thub/charts/keycloak-config/values.yaml
@@ -27,3 +27,6 @@ realmAdminPassword: ""
 publicServerUrl: "https://keycloak.hcl-testcloud.com"
 # URL which is only accessible within the k8s cluster
 internalServerUrl: "http://keycloakx-http.keycloak:80"
+# Whether or not to have the users created in Keycloak will automatically have their
+# "Email verified" property to true
+autoVerifyKeycloakUserEmail: true

--- a/charts/thub/values.yaml
+++ b/charts/thub/values.yaml
@@ -345,6 +345,9 @@ keycloak-config:
   publicServerUrl: "https://keycloak.hcl-testcloud.com"
   # URL which is only accessible within the k8s cluster
   internalServerUrl: "http://keycloakx-http.keycloak:80"
+  # Whether or not to have the users created in Keycloak will automatically have their
+  # "Email verified" property to true. This config is used in our user-service.
+  autoVerifyKeycloakUserEmail: true
 
 global:
   activemqBrokerConfigMapName: mq-broker-config


### PR DESCRIPTION
Set autoVerifyKeycloakUserEmail config property with a default value of true, which is the default value of the property in the `user-service`, so we can override the default if needed